### PR TITLE
chore(): http listening port from env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Compiled binary
+k8spacket
+skaffold/
+# Editor
+.idea
+README.md
+skaffold.yaml
+dashboards/
+docs/
+.git/
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Compiled binary
 k8spacket
-
+skaffold/overlays/*
 # Editor
 .idea
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN chown k8spacket:k8spacket /home/k8spacket/*
 
 RUN chgrp k8spacket /home/k8spacket/k8spacket && chmod 750 /home/k8spacket/k8spacket
 
-RUN setcap cap_net_raw,cap_net_admin=ep /home/k8spacket/k8spacket
+RUN setcap cap_net_raw,cap_net_admin=eip /home/k8spacket/k8spacket
 
 USER k8spacket
 

--- a/k8spacket.go
+++ b/k8spacket.go
@@ -6,15 +6,25 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"log"
 	"net/http"
+	"os"
 )
 
+func getEnv(key, fallback string) string {
+    if value, ok := os.LookupEnv(key); ok {
+        return value
+    }
+    return fallback
+}
+
 func main() {
+	var port = getEnv("HTTP_LISTENING_PORT", "8080")
+	var listeningAddressPort = os.Getenv("HTTP_LISTENING_ADDR") + ":" + port
 	tcp.StartListeners()
-	log.Printf("Serving requests on port 8080")
+	log.Printf("Serving requests on " + listeningAddressPort)
 	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/connections", nodegraph.ConnectionHandler)
 	http.HandleFunc("/api/graph/fields", nodegraph.NodeGraphFieldsHandler)
 	http.HandleFunc("/api/graph/data", nodegraph.NodeGraphDataHandler)
 	http.HandleFunc("/api/health", nodegraph.Health)
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	log.Fatal(http.ListenAndServe(listeningAddressPort, nil))
 }

--- a/metrics/nodegraph/o11y_controller.go
+++ b/metrics/nodegraph/o11y_controller.go
@@ -13,6 +13,13 @@ import (
 	"strings"
 )
 
+func getEnv(key, fallback string) string {
+    if value, ok := os.LookupEnv(key); ok {
+        return value
+    }
+    return fallback
+}
+
 func Health(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(200)
 }
@@ -48,7 +55,7 @@ func NodeGraphDataHandler(w http.ResponseWriter, r *http.Request) {
 	var connectionItems = make(map[string]model.ConnectionItem)
 
 	for _, ip := range k8spacketIps {
-		resp, err := http.Get(fmt.Sprintf("http://%s:8080/connections?%s", ip, r.URL.Query().Encode()))
+		resp, err := http.Get(fmt.Sprintf("http://%s:%s/connections?%s", ip, getEnv("HTTP_LISTENING_PORT", "8080"), r.URL.Query().Encode()))
 
 		if err != nil {
 			fmt.Print(err.Error())

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,39 @@
+apiVersion: skaffold/v2beta28
+kind: Config
+metadata:
+  name: k8spacket
+build:
+  artifacts:
+  - image: k8spacket/k8spacket
+    context: .
+    docker:
+      dockerfile: Dockerfile
+deploy:
+  kustomize:
+    paths:
+    - skaffold/base
+profiles:
+- name: shokohsc
+  build:
+    artifacts:
+    - image: shokohsc/k8spacket
+      kaniko:
+        cache:
+          repo: shokohsc/k8spacket
+        dockerfile: Dockerfile
+    cluster:
+      dockerConfig:
+        secretName: kaniko-secret
+      namespace: kaniko
+      pullSecretName: kaniko-secret
+      resources:
+        limits:
+          cpu: "2"
+          memory: 2Gi
+        requests:
+          cpu: "1"
+          memory: 1Gi
+  deploy:
+    kustomize:
+      paths:
+      - skaffold/overlays/shokohsc

--- a/skaffold/base/daemonset.yaml
+++ b/skaffold/base/daemonset.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: k8spacket
+  labels:
+    app.kubernetes.io/name: k8spacket
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k8spacket
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: k8spacket
+        name: k8spacket
+    spec:
+      serviceAccountName: k8spacket
+      hostNetwork: true
+      securityContext:
+        runAsUser: 1000
+      containers:
+        - name: k8spacket
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: true
+            capabilities:
+              add:
+              - NET_ADMIN
+          image: k8spacket/k8spacket
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1500Mi
+            requests:
+              cpu: 250m
+              memory: 1000Mi
+          env:
+          - name: K8S_PACKET_NAME_LABEL_VALUE
+            value: k8spacket
+          - name: K8S_PACKET_HIDE_SRC_PORT
+            value: "true"
+          - name: K8S_PACKET_REVERSE_GEOIP2_DB_PATH
+            value: /home/k8spacket/GeoLite2-City.mmdb
+          - name: K8S_PACKET_REVERSE_WHOIS_REGEXP
+            value: (?:OrgName:|org-name:)\s*(.*)
+          - name: K8S_PACKET_TCP_ASSEMBLER_MAX_PAGES_PER_CONN
+            value: "50"
+          - name: K8S_PACKET_TCP_ASSEMBLER_MAX_PAGES_TOTAL
+            value: "50"
+          - name: K8S_PACKET_TCP_ASSEMBLER_FLUSHING_PERIOD
+            value: 10s
+          - name: K8S_PACKET_TCP_ASSEMBLER_FLUSHING_CLOSE_OLDER_THAN
+            value: 20s
+          - name: K8S_PACKET_TCP_LISTENER_INTERFACES_COMMAND
+            value: ip address | grep @ | sed -E 's/.* (\w+)@.*/\1/' | tr '\n' ',' | sed 's/.$//'
+          - name: K8S_PACKET_TCP_LISTENER_INTERFACES_REFRESH_PERIOD
+            value: 10s

--- a/skaffold/base/kustomization.yaml
+++ b/skaffold/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: k8spacket
+resources:
+  - namespace.yaml
+  - daemonset.yaml
+  - service.yaml
+  - rbac.yaml

--- a/skaffold/base/namespace.yaml
+++ b/skaffold/base/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8spacket

--- a/skaffold/base/rbac.yaml
+++ b/skaffold/base/rbac.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8spacket
+  namespace: k8spacket
+  labels:
+    app.kubernetes.io/name: k8spacket
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8spacket:k8spacket
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - "pods"
+    - "services"
+    verbs:
+    - "get"
+    - "watch"
+    - "list"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8spacket:k8spacket
+subjects:
+  - kind: ServiceAccount
+    name: k8spacket
+    namespace: k8spacket
+roleRef:
+  kind: ClusterRole
+  name: k8spacket:k8spacket
+  apiGroup: rbac.authorization.k8s.io

--- a/skaffold/base/service.yaml
+++ b/skaffold/base/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8spacket
+  labels:
+    app.kubernetes.io/name: k8spacket
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: k8spacket


### PR DESCRIPTION
Allows to specify from environment variable the address & port k8spacket exposes its http server, fixes #2 
On my cluster `1.20.7` at home, cannot run it without `=eip` nor `runAsUser: 0`
Any idea why would that be the case ?